### PR TITLE
Fix Offset Not Existing Issue

### DIFF
--- a/src/main/java/frc/robot/SwerveConfig.java
+++ b/src/main/java/frc/robot/SwerveConfig.java
@@ -71,23 +71,23 @@ public class SwerveConfig {
 
         public static final SwerveModule frontRightModule = new SwerveModule(kfrontRightRotID,
                         kfrontRightTransID, kfrontRightRotEncoderID,
-                        SwerveConstants.kfrontRightRotEncoderOffset, kfrontRightRotInverse,
+                        kfrontRightRotInverse,
                         kfrontRightTransInverse, frontRightRotPID);
 
         public static final SwerveModule frontLeftModule = new SwerveModule(kfrontLeftRotID,
                         kfrontLeftTransID, kfrontLeftRotEncoderID,
-                        SwerveConstants.kfrontLeftRotEncoderOffset, kfrontLeftRotInverse,
+                        kfrontLeftRotInverse,
                         kfrontLeftTransInverse, frontLeftRotPID);
 
         public static final SwerveModule backRightModule = new SwerveModule(kbackRightRotID,
                         kbackRightTransID, kbackRightRotEncoderID,
-                        SwerveConstants.kbackRightRotEncoderOffset, kbackRightRotInverse,
+                        kbackRightRotInverse,
                         kbackRightTransInverse, backRightRotPID);
 
-        public static final SwerveModule backLeftModule =
-                        new SwerveModule(kbackLeftRotID, kbackLeftTransID, kbackLeftRotEncoderID,
-                                        SwerveConstants.kbackLeftRotEncoderOffset,
-                                        kbackLeftRotInverse, kbackLeftTransInverse, backLeftRotPID);
+        public static final SwerveModule backLeftModule = new SwerveModule(kbackLeftRotID,
+                        kbackLeftTransID, kbackLeftRotEncoderID,
+                        kbackLeftRotInverse, 
+                        kbackLeftTransInverse, backLeftRotPID);
 
         public static final SwerveModule[] swerveModules =
                         {frontLeftModule, frontRightModule, backLeftModule, backRightModule};

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -24,7 +24,6 @@ public class SwerveModule {
     private int _rotID;
     private int _transID;
     private int _rotEncoderID;
-    private double _rotEncoderOffset;
     private boolean _rotInverse;
     private boolean _transInverse;
     private PIDController _rotPID;
@@ -40,13 +39,12 @@ public class SwerveModule {
 
     public double PIDOutput = 0.0;
     public double desiredRadians = 0.0;
-    public SwerveModule(int rotID, int transID, int rotEncoderID, double rotEncoderOffset,
+    public SwerveModule(int rotID, int transID, int rotEncoderID,
             boolean rotInverse, boolean transInverse, PIDController rotPID) {
         // Setting Parameters
         _rotID = rotID;
         _transID = transID;
         _rotEncoderID = rotEncoderID;
-        _rotEncoderOffset = rotEncoderOffset;
         _rotInverse = rotInverse;
         _transInverse = transInverse;
 


### PR DESCRIPTION
Fixes a small bug introduced by the Mk4 Changes PR where the offsets are removed since they are now in the firmware, yet the swerve module wasn't updated to fix that, leading to the branch not building