### PR TITLE
Fix bug with extension ratio

### DIFF
--- a/src/main/java/frc/robot/subsystems/ArmControlSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmControlSubsystem.java
@@ -267,8 +267,7 @@ public class ArmControlSubsystem extends SubsystemBase {
 
   // convert encoder rotations to distance inches
   public double getCurrentExtensionIn() {
-    return mExtensionEncoder.getPosition() * ArmConstants.EXT_MOTOR_TO_BELT_IN
-        * ArmConstants.EXT_ENCODER_RES;
+    return mExtensionEncoder.getPosition() * ArmConstants.EXT_MOTOR_TO_BELT_IN;
   }
 
 


### PR DESCRIPTION
Small bug fix with the extension encoder ratios. Spark max encoders do not use encoder resolution in setpoint calculations like falcons do, which is why I delete the extra conversion.