### PR TITLE
Arm safety features for pivot and extension (with override buttons)

### DIFF
--- a/src/main/java/frc/robot/commands/DefaultArmCommand.java
+++ b/src/main/java/frc/robot/commands/DefaultArmCommand.java
@@ -107,10 +107,15 @@ public class DefaultArmCommand extends CommandBase {
 
           );
       command.schedule();
-    }
+    } else if (Input.getLeftBumper()) {
+      // toggling off override of arm coast
+      ArmControlSubsystem.setPivOverride(false);
+    } else if (Input.getRightBumper()) {
+      ArmControlSubsystem.setExtOverride(false);
 
-    if (Input.isUltraInstinct()) {
-      mArmControlSubsystem.setmUltraInstinct(!mArmControlSubsystem.getmUltraInstinct());
+      if (Input.isUltraInstinct()) {
+        mArmControlSubsystem.setmUltraInstinct(!mArmControlSubsystem.getmUltraInstinct());
+      }
     }
 
   }

--- a/src/main/java/frc/robot/constants/ArmConstants.java
+++ b/src/main/java/frc/robot/constants/ArmConstants.java
@@ -62,6 +62,7 @@ public class ArmConstants {
   // Limits To Angles
   public static final double MIN_PIV_ANGLE_RAD = Units.degreesToRadians(14); // 33
   public static final double MAX_PIV_ANGLE_RAD = Units.degreesToRadians(115.0);
+  public static final double MAX_EXT_TOUCHES_GROUND_ANGLE_RAD = Units.degreesToRadians(33);
 
   // Limit to Extension
   public static final double MIN_EXT_LEN_IN = 0;
@@ -72,6 +73,8 @@ public class ArmConstants {
   public static final double PHYSICAL_MAX_PIV_RAD_SEC = Units.degreesToRadians(142);
   public static final double MAX_PIV_RATE_PERCENT_SEC =
       MAX_PIV_RATE_RAD_SEC / PHYSICAL_MAX_PIV_RAD_SEC;
+
+  public static final double PIV_POS_Y_IN = 45.75; // distance between pivot point and ground
 
 
   // IDs

--- a/src/main/java/frc/robot/subsystems/ArmControlSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmControlSubsystem.java
@@ -295,6 +295,20 @@ public class ArmControlSubsystem extends SubsystemBase {
         (Boolean bool) -> new PrintCommand("getName()"), this::atTelescopeSetpoint, this);
   }
 
+  /*
+   * Returns current pivot velocity in radians per second
+   */
+  public double getCurrentPivotVelocity() {
+    return mLeftPivotController.getSelectedSensorVelocity() * ArmConstants.PIVOT_ENCODER_RES
+        * ArmConstants.PIV_MOTOR_TO_GEAR_ROT * 100 * 2 * Math.PI;
+  }
+
+  /*
+   * Returns extension velocity in inches per second
+   */
+  public double getCurrentExtVelocity() {
+    return mExtensionEncoder.getVelocity() * ArmConstants.EXT_MOTOR_TO_BELT_IN / 60;
+  }
 
   public double getCurrentPivotRotation(boolean inRadians) {
     double rotation;


### PR DESCRIPTION
Added pivot safety features
- added code to identify hazard regions for the pivot and prevent the arm from rotating into them
- added code to set the pivot mode to coast if it's not functioning as intended (e.g., something in the path of the pivot)
- added an override button (left bumper) to change the pivot mode from coast to break

Added extension safety features
- added code to identify hazard regions for the pivot and prevent the arm from extending into them
- added code to set the extension mode to coast if it's not functioning as intended (e.g., something in the path of the extension)
- added an override button (right bumper) to change the extension mode from coast to break